### PR TITLE
Remove Enmap 

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -3,7 +3,6 @@ const Discord = require("discord.js");
 const client = new Discord.Client({ ws: { intents: Discord.Intents.ALL }});
 const config = require("./config.json");
 const fs = require("fs")
-const Enmap = require("enmap")
 
 client.config = config;
 
@@ -16,7 +15,7 @@ fs.readdir("./events/", (err, files) => {
     });
 });
 
-client.commands = new Enmap();
+client.commands = new Map();
 
 fs.readdir("./commands/", (err, files) => {
     if (err) return console.error(err);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "homepage": "discord.gg/yzqma4y",
     "dependencies": {
         "discord.js": "latest",
-        "enmap": "latest",
         "fs": "latest",
         "genius-lyrics-api": "^3.0.3",
         "js-yaml": "^3.14.0",


### PR DESCRIPTION
## Changes
- Removed Enmap dependency
- Replaced Enmap with Map


## Why?
- Enmap’s extra utilities aren’t used through this project, thus there’s absolutely no benefit using it over a JS map; Essentially the project is just importing a dependency & adding bloat to the project for absolutely no reason- thus it should be replaced and optimized.