### PR TITLE
Ensure the message is sent before the client is shut down

### DIFF
--- a/commands/shutdown.js
+++ b/commands/shutdown.js
@@ -1,4 +1,4 @@
 exports.run = (client, message, args) => {
     if (message.author.id !== client.config.ownerid) return;
-    message.channel.send('Shutting down.').then(client.destroy())
+    message.channel.send('Shutting down.').then(() => client.destroy())
 }


### PR DESCRIPTION
`client.destroy()` certainly does not return a function, I think you meant to do this instead.